### PR TITLE
Add full url

### DIFF
--- a/src/Loggers/RequestLogger.php
+++ b/src/Loggers/RequestLogger.php
@@ -22,14 +22,15 @@ class RequestLogger implements RequestLoggerContract
     {
         $data = [
             'url' => $request->getRequestUri(),
+            'full_url' => $request->getUri(),
             'method' => $request->getMethod(),
             'headers' => $request->headers->all(),
             'body' => $request->getContent(),
             'user' => $request->getUser(),
         ];
+
         $data = $this->filter($data);
+
         $this->logManager->channel($channel)->debug('Request: ' . json_encode($data));
     }
-
-
 }

--- a/src/Loggers/RequestLogger.php
+++ b/src/Loggers/RequestLogger.php
@@ -21,8 +21,7 @@ class RequestLogger implements RequestLoggerContract
     public function __invoke(Request $request, string $channel): void
     {
         $data = [
-            'url' => $request->getRequestUri(),
-            'full_url' => $request->getUri(),
+            'url' => $request->getUri(),
             'method' => $request->getMethod(),
             'headers' => $request->headers->all(),
             'body' => $request->getContent(),

--- a/src/Loggers/ResponseLogger.php
+++ b/src/Loggers/ResponseLogger.php
@@ -22,7 +22,7 @@ class ResponseLogger implements ResponseLoggerContract
     public function __invoke(Request $request, Response $response, string $channel): void
     {
         $data = [
-            'url' => $request->getRequestUri(),
+            'url' => $request->getUri(),
             'method' => $request->getMethod(),
             'status' => $response->getStatusCode(),
             'headers' => $response->headers->all(),


### PR DESCRIPTION
Noticed we don't display the full url, thought this may of helped us spotted the missing `https`.

```
[2022-06-22 10:50:07] local.DEBUG: Request: [{"url":"\/api\/v1\/crisis-support\/resources"},{"full_url":"http:\/\/zeffr-pdz.local:8080\/api\/v1\/crisis-support\/resources"},{"method":"GET"}, ...
[2022-06-22 10:50:07] local.DEBUG: Response: [{"url":"\/api\/v1\/crisis-support\/resources"},{"full_url":"http:\/\/zeffr-pdz.local:8080\/api\/v1\/crisis-support\/resources"},{"method":"GET"}, ... 
```